### PR TITLE
feat: add ipfs fallback gateways in audio tag

### DIFF
--- a/pkg/sgtm/page_post.tmpl.html
+++ b/pkg/sgtm/page_post.tmpl.html
@@ -25,12 +25,16 @@
       <div class="col-md-8">
         <h1>{{.Post.Post.Title}}</h1>
         <p>by <a href="{{.Post.Post.Author.CanonicalURL}}"><img height="30" src="{{.Post.Post.Author.Avatar}}" />@{{.Post.Post.Author.Slug}}</a></p>
-        
+
         {{if .Post.Post.IsSoundCloud}}
           <iframe id="soundcloud-player" width=100% height=166 scrolling=no frameborder=no allow=autoplay
             src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{.Post.Post.SoundCloudID}}{{with .Post.Post.SoundCloudSecretToken}}%3Fsecret_token%3D{{.}}{{end}}&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=true&show_reposts=false&show_teaser=false"></iframe>
         {{else}}{{if .Post.Post.IsIPFS}}
-          <audio controls src="/post/{{ .Post.Post.ID }}/download">
+          <audio controls>
+            <source  src="/post/{{.Post.Post.ID}}/download" />
+            <source  src="https://gateway.ipfs.io/ipfs/{{.Post.Post.IPFSCID}}" />
+            <source  src="https://ipfs.io/ipfs/{{.Post.Post.IPFSCID}}" />
+            <source  src="https://jorropo.ovh/ipfs/{{.Post.Post.IPFSCID}}" />
             Your browser does not support the
             <code>audio</code> element.
           </audio>

--- a/pkg/sgtm/page_post.tmpl.html
+++ b/pkg/sgtm/page_post.tmpl.html
@@ -34,6 +34,7 @@
             <source  src="/post/{{.Post.Post.ID}}/download" />
             <source  src="https://gateway.ipfs.io/ipfs/{{.Post.Post.IPFSCID}}" />
             <source  src="https://ipfs.io/ipfs/{{.Post.Post.IPFSCID}}" />
+            <source src="https://cloudflare-ipfs.com/ipfs/{{.Post.Post.IPFSCID}}" />
             <source  src="https://jorropo.ovh/ipfs/{{.Post.Post.IPFSCID}}" />
             Your browser does not support the
             <code>audio</code> element.


### PR DESCRIPTION
Adds ipfs.io and gateway.ipfs.io as fallbacks for audio streaming, this is already useful in dev as it fixes audio streaming from an ios phone conected to an sgtm instance on LAN

Also fixes a race that could happen if a Read happens after a Seek has closed the reader but also before the Seek has locked the mutex