### PR TITLE
fix: changing jorropo.ovh to jorropo.net

### DIFF
--- a/pkg/sgtm/page_post.tmpl.html
+++ b/pkg/sgtm/page_post.tmpl.html
@@ -35,7 +35,7 @@
             <source  src="https://gateway.ipfs.io/ipfs/{{.Post.Post.IPFSCID}}" />
             <source  src="https://ipfs.io/ipfs/{{.Post.Post.IPFSCID}}" />
             <source src="https://cloudflare-ipfs.com/ipfs/{{.Post.Post.IPFSCID}}" />
-            <source  src="https://jorropo.ovh/ipfs/{{.Post.Post.IPFSCID}}" />
+            <source  src="https://jorropo.net/ipfs/{{.Post.Post.IPFSCID}}" />
             Your browser does not support the
             <code>audio</code> element.
           </audio>


### PR DESCRIPTION
I'm moving my domain and vps (jorropo.ovh is currently the old slow VPS, in the future it will likely point to the same place as jorropo.net but that not yet done).