### PR TITLE
chore(tool): add `tool/ipfs-pin.sh` script

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@
 
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 ImgBotApp <ImgBotHelp@gmail.com>
+Jorropo <jorropo.pgm@gmail.com>
 Manfred Touron <94029+moul@users.noreply.github.com>
 Manfred Touron <m@42.am>
 moul-bot <bot@moul.io>

--- a/gen.sum
+++ b/gen.sum
@@ -1,2 +1,2 @@
 684ebb244d2a791ee020fd8da38d4d10a171d2c1  ./api/sgtm.proto
-034f32b1cbdac6ec6e02c1244eed70c90c127adf  Makefile
+06c584c29d15fd222be369d6a3bbf6fd1e72d3c3  Makefile

--- a/tool/ipfs-pin.sh
+++ b/tool/ipfs-pin.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+URL=${1:-https://sgtm.club}
+set -x
+http $URL/api/v1/PostList | jq -r '.posts[].ipfs_cid | select(.!=null)' | xargs ipfs pin add


### PR DESCRIPTION
simple script that retrieves CIDs from the SGTM API and pin them on the local
IPFS daemon for high-availability (a.k.a. the poorman's IPFS cluster).

    moul@fwrz:~/go/src/moul.io/sgtm (dev/moul/ipfs-pin) $ ./tool/ipfs-pin.sh
    + http https://sgtm.club/api/v1/PostList
    + jq -r .posts[].ipfs_cid | select(.!=null)
    + xargs ipfs pin add
    pinned QmQmiy95hGoxEgjYEL6Qh4qGqjzp7FUdXHGJrJB1buHLVD recursively
    pinned Qmd3kRr14S51Pogwm2dBMGfgeJRrmXohrrtbQ16GpnRBhB recursively
    pinned QmVAFFxjhZthLi8mc85r2FqiNHVpdKHUYr34kMr7aGfX4z recursively
    pinned QmU44C5tqWGckrafyVNrgQe6yU3jgzhmB57UTjspDRVPJC recursively
    pinned QmZNvpmkvvH2iLk8PnKEdFNxrqatD8HtkQzzmmEq3rhNtg recursively
    pinned QmZsa6f4xQJ5WZNrP2vdwmXUshbbVWkGkg8SxaAwT77ynW recursively
    pinned Qme9wJ5DqFYA3Vqn9FkC5gpWXzthjF3NE4iyRTa2asW3Ky recursively
    pinned QmSQhv5BTg2KrZRA8vrDDLDpM6oBtfB6ZnCDouppdEGXWY recursively
    pinned QmPpyLwr9Aa3SiAczzHNCZLupvRJ4n65VSiWRCLjUHrhMK recursively
    pinned QmVHSCr2QjECLaLH7GnxnmWY6PU4oawbqFRZTxraJGaEDj recursively
    pinned QmWUcbDraf1sXEkrmbfBpjMW9dDaTkVnB5stV9FubDMPvq recursively
    moul@fwrz:~/go/src/moul.io/sgtm (dev/moul/ipfs-pin) $


<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->